### PR TITLE
Ignore Genesis Block if received

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -26,6 +26,7 @@ use rand::Rng;
 use sawtooth_sdk::consensus::{engine::*, service::Service};
 
 const DEFAULT_WAIT_TIME: u64 = 0;
+const NULL_BLOCK_IDENTIFIER: [u8; 8] = [0, 0, 0, 0, 0, 0, 0, 0];
 
 #[derive(Default)]
 struct LogGuard {
@@ -242,6 +243,11 @@ impl Engine for DevmodeEngine {
                         }
                         Update::BlockNew(block) => {
                             info!("Checking consensus data: {:?}", block);
+
+                            if &block.previous_id == &NULL_BLOCK_IDENTIFIER {
+                                warn!("Received genesis block; ignoring");
+                                continue;
+                            }
 
                             if check_consensus(&block) {
                                 info!("Passed consensus check: {:?}", block);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -56,7 +56,7 @@ impl DevmodeService {
     }
 
     fn get_block(&mut self, block_id: &BlockId) -> Block {
-        debug!("Getting block {:?}", &block_id);
+        debug!("Getting block {}", to_hex(&block_id));
         self.service
             .get_blocks(vec![block_id.clone()])
             .expect("Failed to get block")
@@ -100,28 +100,28 @@ impl DevmodeService {
     }
 
     fn check_block(&mut self, block_id: BlockId) {
-        debug!("Checking block {:?}", block_id);
+        debug!("Checking block {}", to_hex(&block_id));
         self.service
             .check_blocks(vec![block_id])
             .expect("Failed to check block");
     }
 
     fn fail_block(&mut self, block_id: BlockId) {
-        debug!("Failing block {:?}", block_id);
+        debug!("Failing block {}", to_hex(&block_id));
         self.service
             .fail_block(block_id)
             .expect("Failed to fail block");
     }
 
     fn ignore_block(&mut self, block_id: BlockId) {
-        debug!("Ignoring block {:?}", block_id);
+        debug!("Ignoring block {}", to_hex(&block_id));
         self.service
             .ignore_block(block_id)
             .expect("Failed to ignore block")
     }
 
     fn commit_block(&mut self, block_id: BlockId) {
-        debug!("Committing block {:?}", block_id);
+        debug!("Committing block {}", to_hex(&block_id));
         self.service
             .commit_block(block_id)
             .expect("Failed to commit block");
@@ -139,7 +139,7 @@ impl DevmodeService {
     }
 
     fn broadcast_published_block(&mut self, block_id: BlockId) {
-        debug!("Broadcasting published block: {:?}", block_id);
+        debug!("Broadcasting published block: {}", to_hex(&block_id));
         self.service
             .broadcast("published", Vec::from(block_id))
             .expect("Failed to broadcast published block");
@@ -304,8 +304,8 @@ impl Engine for DevmodeEngine {
                         // block in progress and start a new one.
                         Update::BlockCommit(new_chain_head) => {
                             info!(
-                                "Chain head updated to {:?}, abandoning block in progress",
-                                new_chain_head
+                                "Chain head updated to {}, abandoning block in progress",
+                                to_hex(&new_chain_head)
                             );
 
                             service.cancel_block();
@@ -324,16 +324,18 @@ impl Engine for DevmodeEngine {
                                 DevmodeMessage::Published => {
                                     let block_id = BlockId::from(message.content);
                                     info!(
-                                        "Received block published message from {:?}: {:?}",
-                                        &sender_id, block_id
+                                        "Received block published message from {}: {}",
+                                        to_hex(&sender_id),
+                                        to_hex(&block_id)
                                     );
                                 }
 
                                 DevmodeMessage::Received => {
                                     let block_id = BlockId::from(message.content);
                                     info!(
-                                        "Received block received message from {:?}: {:?}",
-                                        &sender_id, block_id
+                                        "Received block received message from {}: {}",
+                                        to_hex(&sender_id),
+                                        to_hex(&block_id)
                                     );
                                     service.send_block_ack(&sender_id, block_id);
                                 }
@@ -341,8 +343,9 @@ impl Engine for DevmodeEngine {
                                 DevmodeMessage::Ack => {
                                     let block_id = BlockId::from(message.content);
                                     info!(
-                                        "Received ack message from {:?}: {:?}",
-                                        &sender_id, block_id
+                                        "Received ack message from {}: {}",
+                                        to_hex(&sender_id),
+                                        to_hex(&block_id)
                                     );
                                 }
                             }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -236,7 +236,7 @@ impl Engine for DevmodeEngine {
 
             match incoming_message {
                 Ok(update) => {
-                    debug!("Received message: {:?}", update);
+                    debug!("Received message: {}", message_type(&update));
 
                     match update {
                         Update::Shutdown => {
@@ -404,6 +404,19 @@ fn to_hex(bytes: &[u8]) -> String {
     }
 
     buf
+}
+
+fn message_type(update: &Update) -> &str {
+    match *update {
+        Update::PeerConnected(_) => "PeerConnected",
+        Update::PeerDisconnected(_) => "PeerDisconnected",
+        Update::PeerMessage(..) => "PeerMessage",
+        Update::BlockNew(_) => "BlockNew",
+        Update::BlockValid(_) => "BlockValid",
+        Update::BlockInvalid(_) => "BlockInvalid",
+        Update::BlockCommit(_) => "BlockCommit",
+        Update::Shutdown => "Shutdown",
+    }
 }
 
 fn check_consensus(block: &Block) -> bool {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -77,7 +77,7 @@ impl DevmodeService {
         while let Err(Error::BlockNotReady) = summary {
             if !self.log_guard.not_ready_to_summarize {
                 self.log_guard.not_ready_to_summarize = true;
-                warn!("Block not ready to summarize");
+                debug!("Block not ready to summarize");
             }
             sleep(time::Duration::from_secs(1));
             summary = self.service.summarize_block();
@@ -89,7 +89,7 @@ impl DevmodeService {
         while let Err(Error::BlockNotReady) = block_id {
             if !self.log_guard.not_ready_to_finalize {
                 self.log_guard.not_ready_to_finalize = true;
-                warn!("Block not ready to finalize");
+                debug!("Block not ready to finalize");
             }
             sleep(time::Duration::from_secs(1));
             block_id = self.service.finalize_block(consensus.clone());


### PR DESCRIPTION
Ignore the genesis block, as it will fail consensus, but should be accepted.  During normal operation, this block should never be sent from the validator.  The validator itself is responsible for genesis block
consensus.

Additionally:

- Log blocks in a readable fashion
- Log block ids in a readable fashion 
- Remove message logging, in order to reduce log clutter.
- downgrade not ready warning to debug, as this is a perfectly valid state