### PR TITLE
[docker-compose] Stop on build failure

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -125,7 +125,7 @@ services:
       - validator
     command: |
       bash -c "
-        cargo build --release
+        cargo build --release && \
         devmode-engine-rust -v --connect tcp://validator:5050
       "
     stop_signal: SIGKILL


### PR DESCRIPTION
By this PR, I have verified that devmode-engine-rust exits when the build failed:

```bash
$ docker-compose up
...
...
...
sawtooth-devmode-engine-rust-local |    Compiling sawtooth-devmode-engine-rust v1.2.4 (/project/sawtooth-devmode)
sawtooth-devmode-engine-rust-local | error[E0425]: cannot find value `foo` in this scope
sawtooth-devmode-engine-rust-local |   --> src/main.rs:40:5
sawtooth-devmode-engine-rust-local |    |
sawtooth-devmode-engine-rust-local | 40 |     foo; // TEST
sawtooth-devmode-engine-rust-local |    |     ^^^ not found in this scope
sawtooth-devmode-engine-rust-local |
sawtooth-devmode-engine-rust-local | error: aborting due to previous error
sawtooth-devmode-engine-rust-local |
sawtooth-devmode-engine-rust-local | For more information about this error, try `rustc --explain E0425`.
sawtooth-devmode-engine-rust-local | error: could not compile `sawtooth-devmode-engine-rust`.
sawtooth-devmode-engine-rust-local |
sawtooth-devmode-engine-rust-local | To learn more, run the command again with --verbose.
sawtooth-devmode-engine-rust-local exited with code 101
```