### PR TITLE
Add debug logs to trace that a block has been finalized

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -84,8 +84,10 @@ impl DevmodeService {
             summary = self.service.summarize_block();
         }
         self.log_guard.not_ready_to_summarize = false;
+        let summary = summary.expect("Failed to summarize block");
+        debug!("Block has been summarized successfully");
 
-        let consensus: Vec<u8> = create_consensus(&summary.expect("Failed to summarize block"));
+        let consensus: Vec<u8> = create_consensus(&summary);
         let mut block_id = self.service.finalize_block(consensus.clone());
         while let Err(Error::BlockNotReady) = block_id {
             if !self.log_guard.not_ready_to_finalize {
@@ -96,8 +98,13 @@ impl DevmodeService {
             block_id = self.service.finalize_block(consensus.clone());
         }
         self.log_guard.not_ready_to_finalize = false;
+        let block_id = block_id.expect("Failed to finalize block");
+        debug!(
+            "Block has been finalized successfully: {}",
+            to_hex(&block_id)
+        );
 
-        block_id.expect("Failed to finalize block")
+        block_id
     }
 
     fn check_block(&mut self, block_id: BlockId) {


### PR DESCRIPTION
Currently only `Block not ready to summarize` is shown in terminal. I think that looks like implying that has a bug. To be clear that is not meaning a bug, I have added the debug messages:


```
sawtooth-devmode-engine-rust-local | DEBUG | devmode_engine_rust: | Finalizing block
sawtooth-devmode-engine-rust-local | DEBUG | devmode_engine_rust: | Block not ready to summarize
sawtooth-devmode-engine-rust-local | DEBUG | devmode_engine_rust: | Block has been summarized successfully
sawtooth-devmode-engine-rust-local | DEBUG | devmode_engine_rust: | Block has been finalized successfully: 5fa3ab9d4c42cecf6c1922529966eebd4ce68fd3f3adda31919f8fc7219dde3b882f30fa4f70bee1c3b66cd8ff5c90c4c6d87a35e7afb1f370d13da0a3c7ba
```