### PR TITLE
Pin Devmode liveness tests to 1-3 nightly validator

### DIFF
--- a/tests/test_devmode_engine_liveness.yaml
+++ b/tests/test_devmode_engine_liveness.yaml
@@ -128,7 +128,7 @@ services:
     stop_signal: SIGKILL
 
   validator-0:
-    image: hyperledger/sawtooth-validator:nightly
+    image: hyperledger/sawtooth-validator:droptarget-nightly
     expose:
       - 4004
       - 8800
@@ -162,7 +162,7 @@ services:
     stop_signal: SIGKILL
 
   validator-1:
-    image: hyperledger/sawtooth-validator:nightly
+    image: hyperledger/sawtooth-validator:droptarget-nightly
     expose:
       - 4004
       - 8800
@@ -184,7 +184,7 @@ services:
     stop_signal: SIGKILL
 
   validator-2:
-    image: hyperledger/sawtooth-validator:nightly
+    image: hyperledger/sawtooth-validator:droptarget-nightly
     expose:
       - 4004
       - 8800
@@ -206,7 +206,7 @@ services:
     stop_signal: SIGKILL
 
   validator-3:
-    image: hyperledger/sawtooth-validator:nightly
+    image: hyperledger/sawtooth-validator:droptarget-nightly
     expose:
       - 4004
       - 8800
@@ -228,7 +228,7 @@ services:
     stop_signal: SIGKILL
 
   validator-4:
-    image: hyperledger/sawtooth-validator:nightly
+    image: hyperledger/sawtooth-validator:droptarget-nightly
     expose:
       - 4004
       - 8800


### PR DESCRIPTION
sawtooth-core is currently working toward 2.0 and may not
be compatibly with this current version of Devmode. For now
the liveness test will continue to be run against 1-3,
the "main" branch for further 1.x development.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>