### PR TITLE
Fix wildcard_in_or_patterns lint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
         0 => console_log_level = LogLevelFilter::Warn,
         1 => console_log_level = LogLevelFilter::Info,
         2 => console_log_level = LogLevelFilter::Debug,
-        3 | _ => console_log_level = LogLevelFilter::Trace,
+        _ => console_log_level = LogLevelFilter::Trace,
     }
 
     let stdout = ConsoleAppender::builder()


### PR DESCRIPTION
This change corrects an issue where a pattern or wildcard is being used, which can be reduced to just the wildcard pattern.
