### PR TITLE
Pin bandit version

### DIFF
--- a/docker/lint
+++ b/docker/lint
@@ -43,7 +43,7 @@ RUN apt-get install -y -q \
     && pip3 install \
     pylint \
     pycodestyle \
-    bandit \
+    bandit==1.7.1 \
     coverage --upgrade
 
 RUN apt-get install -y -q \


### PR DESCRIPTION
The 1.7.2 release of Bandit drops support for python 3.6, which is the latest
available for ubuntu bionic.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>